### PR TITLE
Add key vault refresh token secret key

### DIFF
--- a/.identity/99_variables.tf
+++ b/.identity/99_variables.tf
@@ -56,7 +56,7 @@ variable "environment_cd_roles" {
 
 variable "github_repository_environment_cd" {
   type = object({
-    reviewers_teams        = list(string)
+    reviewers_teams = list(string)
   })
   description = "GitHub Continous Integration roles"
 }

--- a/infra/src/core/01_function.tf
+++ b/infra/src/core/01_function.tf
@@ -25,6 +25,11 @@ data "azurerm_key_vault_secret" "newsletter-MAILUP-PASSWORD" {
   key_vault_id = module.key_vault.id
 }
 
+data "azurerm_key_vault_secret" "newsletter-MAILUP-REFRESH-TOKEN" {
+  name         = "newsletter-REFRESH-TOKEN"
+  key_vault_id = module.key_vault.id
+}
+
 data "azurerm_key_vault_secret" "newsletter-RECAPTCHA-SECRET" {
   name         = "newsletter-RECAPTCHA-SECRET"
   key_vault_id = module.key_vault.id

--- a/infra/src/core/01_function.tf
+++ b/infra/src/core/01_function.tf
@@ -115,11 +115,12 @@ resource "azurerm_linux_function_app" "app" {
     MAILUP_ALLOWED_LISTS  = "2,4,6,7"
 
     // Mailup account
-    MAILUP_CLIENT_ID = data.azurerm_key_vault_secret.newsletter-MAILUP-CLIENT-ID.value
-    MAILUP_SECRET    = data.azurerm_key_vault_secret.newsletter-MAILUP-SECRET.value
-    MAILUP_USERNAME  = data.azurerm_key_vault_secret.newsletter-MAILUP-USERNAME.value
-    MAILUP_PASSWORD  = data.azurerm_key_vault_secret.newsletter-MAILUP-PASSWORD.value
-    RECAPTCHA_SECRET = data.azurerm_key_vault_secret.newsletter-RECAPTCHA-SECRET.value
+    MAILUP_CLIENT_ID     = data.azurerm_key_vault_secret.newsletter-MAILUP-CLIENT-ID.value
+    MAILUP_SECRET        = data.azurerm_key_vault_secret.newsletter-MAILUP-SECRET.value
+    MAILUP_USERNAME      = data.azurerm_key_vault_secret.newsletter-MAILUP-USERNAME.value
+    MAILUP_PASSWORD      = data.azurerm_key_vault_secret.newsletter-MAILUP-PASSWORD.value
+    MAILUP_REFRESH_TOKEN = data.azurerm_key_vault_secret.newsletter-MAILUP-REFRESH-TOKEN.value
+    RECAPTCHA_SECRET     = data.azurerm_key_vault_secret.newsletter-RECAPTCHA-SECRET.value
 
   }
 

--- a/infra/src/core/README.md
+++ b/infra/src/core/README.md
@@ -39,8 +39,10 @@
 | [azurerm_client_config.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
 | [azurerm_key_vault_secret.newsletter-MAILUP-CLIENT-ID](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.newsletter-MAILUP-PASSWORD](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.newsletter-MAILUP-REFRESH-TOKEN](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.newsletter-MAILUP-SECRET](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_key_vault_secret.newsletter-MAILUP-USERNAME](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
+| [azurerm_key_vault_secret.newsletter-RECAPTCHA-SECRET](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/key_vault_secret) | data source |
 | [azurerm_subscription.current](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
 
 ## Inputs


### PR DESCRIPTION
#### List of Changes
- Add secret key to Key Vault due to change api auth method

#### Motivation and Context
Grant_type=password is used to get the auth token used in the api call, but this exposes us to breakage when the password is changed periodically.
With this pr we want to prepare to API auth change method

https://helpmailup.atlassian.net/wiki/spaces/mailupapi/pages/36342032/Authorization+code+grant+flow

#### How Has This Been Tested?


#### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
